### PR TITLE
Make modifications for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,9 @@ IF(NOT MYPROJECT_DONTSET_COMPILER_FLAGS_INTERNAL)
         
   ELSEIF ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC" )
     MESSAGE(WARNING "MSVC is not supported yet, trying to set compiler flags anyway!")
-		SET(CMAKE_CXX_FLAGS "-std=c++11" CACHE STRING "Flags for CXX Compiler" FORCE)
+		SET(CMAKE_CXX_FLAGS "/arch:SSE2" CACHE STRING "Flags for CXX Compiler" FORCE)
+		# NOTE: SSE is already enabled for x64 compiler
+		# as per http://stackoverflow.com/questions/1067630/sse2-option-in-visual-c-x64
   ENDIF()
 ENDIF()
 

--- a/cmake/CheckFloatPrecision.cmake
+++ b/cmake/CheckFloatPrecision.cmake
@@ -90,11 +90,15 @@ macro(check_float_precision)
   }
  
   int main (int argc, char **argv) {
+    #if defined(_MSC_VER) && defined(_WIN64 )
+        return 1;
+    #else
     double d = div (2877.0, 1000000.0);
     char buf[255];
     sprintf(buf, \"%.30f\", d);
     // see if the result is actually in double precision
     return strncmp(buf, \"0.00287699\", 10) == 0 ? 0 : 1;
+	#endif
   }
  " HAVE__CONTROLFP)
 
@@ -116,11 +120,15 @@ macro(check_float_precision)
   }
  
   int main (int argc, char **argv) {
+    #if defined(_MSC_VER) && defined(_WIN64 )
+        return 1;
+    #else
     double d = div (2877.0, 1000000.0);
     char buf[255];
     sprintf(buf, \"%.30f\", d);
     // see if the result is actually in double precision
     return strncmp(buf, \"0.00287699\", 10) == 0 ? 0 : 1;
+    #endif
   }
  " HAVE__CONTROLFP_S)
 

--- a/external/GeometryPredicates/include/ApproxMVBB/GeometryPredicates/xpfpa.h
+++ b/external/GeometryPredicates/include/ApproxMVBB/GeometryPredicates/xpfpa.h
@@ -68,7 +68,38 @@
 # pragma fenv_access (on)
 #endif // _MSC_VER
 
-#ifdef HAVE__CONTROLFP_S
+// MSVC does NOT support _control_fp stuff on x64!
+// Define everything as NOP.
+#if defined(_MSC_VER) && defined(_WIN64 )
+
+// float.h defines _controlfp_s
+# include <float.h>
+
+# define XPFPA_DECLARE()
+
+# define XPFPA_SWITCH_DOUBLE()
+# define XPFPA_SWITCH_SINGLE()
+# define XPFPA_SWITCH_DOUBLE_EXTENDED()
+# define XPFPA_RESTORE()
+// We do NOT use the volatile return trick since _controlfp_s is a function
+// call and thus FP registers are saved in memory anyway. However, we do use
+// a variable to ensure that the expression passed into val will be evaluated
+// *before* switching back contexts.
+# define XPFPA_RETURN_DOUBLE(val) \
+			            { \
+                return (val); \
+			            }
+# define XPFPA_RETURN_SINGLE(val) \
+			            { \
+                return (val); \
+			            }
+// This won't work, but we add a macro for it anyway.
+# define XPFPA_RETURN_DOUBLE_EXTENDED(val) \
+			            { \
+                return (val); \
+			            }
+
+#elif HAVE__CONTROLFP_S
 
 // float.h defines _controlfp_s
 # include <float.h>


### PR DESCRIPTION
Remove _controlfp instructions if compiling on X64.
Change CMake checks for floating point accuracies on X64.
